### PR TITLE
✨주식시세 api 통한 적중률 기본 로직 작성

### DIFF
--- a/reports/urls.py
+++ b/reports/urls.py
@@ -4,7 +4,11 @@ from .views import *
 
 router = DefaultRouter()
 
+router.register(r'currency', CurrencyViewSet)
 router.register(r'report', ReportViewSet)
+router.register(r'stock', StockViewSet)
+router.register(r'point', PointViewSet)
+router.register(r'writes', WritesViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/test_code/stockPrice.py
+++ b/test_code/stockPrice.py
@@ -1,0 +1,64 @@
+from dotenv import load_dotenv
+import os
+import requests
+import xml.etree.ElementTree as ET ## XML 데이터 파싱을 위한 패키지
+
+load_dotenv()
+stockPriceApiBaseurl = "https://apis.data.go.kr/1160100/service/GetStockSecuritiesInfoService/getStockPriceInfo"
+
+
+url = "http://apis.data.go.kr/1160100/service/GetStockSecuritiesInfoService/getStockPriceInfo"
+
+
+# 요청 파라미터 설정
+params = {
+    "serviceKey": os.getenv("STOCK_PRICE_SERVICE_KEY"),
+    "numOfRows" : "365", ## 검색 일수
+    "itmsNm": "LG이노텍", ## 종목 이름
+    "beginBasDt" : "20230807", ## 검색 시작 날짜
+    "endBasDt" : "20230919"    ## 검색 종료 날짜
+}
+
+# GET 요청 보내기
+response = requests.get(url, params=params)
+
+
+# 응답 확인
+if response.status_code == 200:
+
+    xml_data = response.content
+
+    root = ET.fromstring(xml_data)
+
+    # clpr 요소 추출
+    basDt_elements = root.findall(".//basDt")
+    clpr_elements = root.findall(".//clpr")
+
+    startPrice = -1
+    # clpr 값 출력
+    for i in range(len(basDt_elements)-1, -1, -1):
+
+        ## 첫번째 날이 기준 날이므로 기준 가격을 정함
+        if (i == len(basDt_elements)-1):
+            startPrice = int(clpr_elements[i].text)
+
+        basDt_element = basDt_elements[i]
+        clpr_element = clpr_elements[i]
+
+        basDt_element = basDt_element.text
+        clpr_value = int(clpr_element.text)
+
+        ## 올랐을 경우
+        if startPrice < clpr_value:
+            priceStatus = "오름"
+
+        elif startPrice > clpr_value:
+            priceStatus = "내림"
+
+        else:
+            priceStatus = ""
+
+        print(f"{basDt_element}의 종가 : {clpr_value} {priceStatus}")
+
+else:
+    print("요청 실패:", response.status_code)

--- a/test_code/tempCodeRunnerFile.py
+++ b/test_code/tempCodeRunnerFile.py
@@ -1,0 +1,4 @@
+response = urllib.request.urlopen(url)
+
+
+# print(response.status_code)


### PR DESCRIPTION
사실 완벽하게 짜놓은 건 아니고 중간 저장느낌으로 올리는 거라 확인은 따로 안하시고 머지해주시는 게 부담이 없으실 것 같네요!

<코드 내용>
공공데이터 포털의 "금융위원회 주식시세" api 사용해서 리포트 작성일 대비 가격 등락을 종가기준으로 days_hit, days_missed, days_to_first_hit, days_to_first_miss 뽑는 로직 작성