### PR TITLE
`init currency` 명령어로 Currency 모델 초기화

### DIFF
--- a/reports/management/commands/init.py
+++ b/reports/management/commands/init.py
@@ -1,0 +1,34 @@
+from django.core.management.base import BaseCommand, CommandError
+from reports.models import Currency
+
+
+class Command(BaseCommand):
+    help = "Initialize some data on database"
+
+    data_types = [
+        "currency",
+    ]
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "data_type",
+            type=str,
+            help=f"Type of data to initialize. Select between: {self.data_types}",
+        )
+
+    def handle(self, *args, **options):
+        data_type = options["data_type"]
+        if data_type not in self.data_types:
+            raise CommandError(f"Unknown data type: {data_type}. Select between: {self.data_types}")
+
+        if data_type == "currency":
+            currencies = [
+                {"name": "won", "code": "KRW"},
+            ]
+
+            for curr in currencies:
+                Currency.objects.get_or_create(name=curr["name"], code=curr["code"])
+
+            self.stdout.write(self.style.SUCCESS("Currency initialized."))
+        
+        return 0


### PR DESCRIPTION
`python manage.py init currency`를 실행하면 DB의 Currency 테이블에
| code | name |
|--------|--------|
| KRW | won | 

이 들어가는 명령어를 만들었습니다. 

## 구현 방법
커스텀 장고 커맨드를 만드는 방식으로 구현했습니다. 
currency 이외에 다른 단어를 쓸 수도 있도록 구현했습니다. 지금은 currency 자리에 아무것도 안 쓰거나 다른 단어를 쓰면 오류 메시지를 출력하고 아무 일도 일어나지 않습니다. 
(KRW, won) 이외에 다른 currency도 코드 한 줄 추가(ex. `{"code": "USD", "name": "dollar"}`)로 가능하도록 구현했습니다. 
데이터는 `Report.objects.get_or_create()`로 추가됩니다. 

## 활용 방법
리포트 크롤링하기 전에 먼저 `python manage.py init currency` 실행 후에 해주시면 됩니다. 

리포트 크롤링 커맨드도 곧 만들어오겠습니다. 