### PR TITLE
`scrape` 명령어로 특정 종목 리포트 스크레이핑 추가

### DIFF
--- a/reports/management/commands/scrape.py
+++ b/reports/management/commands/scrape.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from django.core.management.base import BaseCommand, CommandError
+from reports.fetch import fetch_stock_reports
+
+
+class Command(BaseCommand):
+    help = "Scrape stock reports related data from Naver and save to DB"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-f",
+            "--file",
+            type=str,
+            help="File containing stock names, one per line",
+        )
+        parser.add_argument(
+            "-s",
+            "--stocks",
+            nargs="+",
+            type=str,
+            help="List of stock names to scrape with spaces in between(ex. 삼성전자 카카오)",
+        )
+
+    def handle(self, *args, **options):
+        file_path = options["file"]
+        stocks = options["stocks"]
+
+        if file_path:
+            path = Path(file_path)
+            if not path.is_file():
+                raise CommandError(
+                    f"File does not exist at the specified path: {file_path}"
+                )
+
+            with path.open(encoding="utf-8") as f:
+                for line in f:
+                    stock_name = line.strip()
+                    if len(stock_name) == 0:
+                        continue
+                    fetch_stock_reports(stock_name)
+
+        elif stocks:
+            for stock_name in stocks:
+                fetch_stock_reports(stock_name)
+
+        else:
+            raise CommandError("Provide either a --file or --stocks argument.")


### PR DESCRIPTION
- `python manage.py scrape --file filename`을 하면 각각의 줄에 종목이름이 담긴 이름 filename 파일을 읽어 그 종목의 리포트를 스크레이핑
- `python manage.py scrape --stocks 네이버 카카오`를 하면 네이버와 카카오의 리포트를 스크레이핑

## 구현 방법
커스텀 장고 커맨드를 만드는 방식으로 구현했습니다.

## 활용 방법
처음 DB에 리포트를 채울 때, 새 리포트가 필요할 때 직접 커맨드를 입력하거나, 이 커맨드가 주기적으로 실행되도록 할 수 있습니다. 