### PR TITLE
remove lines that interferes analyst average calculation

### DIFF
--- a/reports/fetch.py
+++ b/reports/fetch.py
@@ -635,14 +635,6 @@ def calculate_hit_rate_of_analyst():
         days_to_first_hit_sum = total["total_days_to_first_hit"]
         days_to_first_miss_sum = total["total_days_to_first_miss"]
 
-        if not (
-            days_hit_sum
-            and days_missed_sum
-            and days_to_first_hit_sum
-            and days_to_first_miss_sum
-        ):
-            continue
-
         print(f"days_hit_sum : {days_hit_sum}")
         print(f"days_missed_sum : {days_missed_sum}")
         print(f"days_to_first_hit_sum : {days_to_first_hit_sum}")


### PR DESCRIPTION
애널리스트 통계 계산 중 분자가 0인 경우에도 계산을 건너뛰는 부분이 있어 수정했습니다. 